### PR TITLE
Fix Plugin = MotionServicePlugin() to class reference

### DIFF
--- a/main.py
+++ b/main.py
@@ -630,5 +630,5 @@ class MotionServicePlugin:
         """Log frontend errors"""
         decky.logger.error(f"FRONTEND: {error}")
 
-# Plugin instancePlugin = MotionServicePlugin
+# Plugin instance
 Plugin = MotionServicePlugin

--- a/main.py
+++ b/main.py
@@ -630,5 +630,5 @@ class MotionServicePlugin:
         """Log frontend errors"""
         decky.logger.error(f"FRONTEND: {error}")
 
-# Plugin instance
-Plugin = MotionServicePlugin()
+# Plugin instancePlugin = MotionServicePlugin
+Plugin = MotionServicePlugin


### PR DESCRIPTION
gave this error previously :

[2025-07-01 14:39:06,394][ERROR]: Failed to start Motion Service! Traceback (most recent call last):
  File "decky_loader/plugin/sandboxed_plugin.py", line 111, in initialize
TypeError: 'MotionServicePlugin' object is not callable